### PR TITLE
Further repairs for HTML.

### DIFF
--- a/srfi-7.html
+++ b/srfi-7.html
@@ -55,7 +55,6 @@ rationale for the need for some kind of configuration control.
 
 <h3>Syntax</h3>
 
-<p>
 <pre id="program">
  &lt;program&gt; --&gt; (program &lt;program clause&gt;+)
 


### PR DESCRIPTION
Unfortunately, a few of the additional HTML corrections—which were all indeed correct corrections—exposed some further issues, in large part because the parser in Racket's standard library is really an XML parser and thus entirely unforgiving about balanced tags. I have follow-up repairs here and for SRFIs 11, 19, 30, 38, 48, 59, 62, and 87. Some, as in this case, are one-line changes: in other cases I also added newlines and or  marked additional paragraphs to try to improve legibility a bit more.

(The deeper explanation for this case and a few others is that a `<pre></pre>` can not properly be nested inside a `<p></p>`: the W3C validator would have recognized that, under modern HTML semantics, the paragraph would be implicitly closed before the `<pre>`, so the `</p>` was dangling from its perspective, but really the paragraph should never have been opened.)